### PR TITLE
Fix recapture crash: use CallWindowProcW instead of direct wndproc call

### DIFF
--- a/src/hook/hookdll.cpp
+++ b/src/hook/hookdll.cpp
@@ -556,7 +556,7 @@ public:
     LRESULT callOriginalWindowProc(HWND hwnd, UINT msg, WPARAM wparam, LPARAM lparam){
         if (captured_windows.count(hwnd)){
             auto& ctx = captured_windows.at(hwnd);
-            return ctx.original_proc(hwnd, msg, wparam, lparam);
+            return ::CallWindowProcW(ctx.original_proc, hwnd, msg, wparam, lparam);
         }else{
             return 0;
         }


### PR DESCRIPTION
Claude helped investigate this issue.

I don't have any experience with C++ Win32 programming and don't really fully believe the explanation it produced (particularly it seems odd to me that calling the wndproc directly would work once but not the second time around).

However, calling CallWindowProcW does seem to be the way the documentation recommends calling the original wndproc, so this fix is at worst harmless. And I can confirm that capturing, stopping, and restarting the capture would 100% crash MSFS and fsmapper before this fix, and now it crashes 0%.

I have a 15gb dump file that I'd be happy to share if you are curious to look into this further.

Closes #18 

## Investigation

The crash manifested as an access violation (0xC0000005) when recapturing an MSFS 2024 popup window that had previously been captured and released without being closed (capture -> stop fsmapper -> recapture same window).

A WER full crash dump was captured and loaded into Visual Studio.

### Call stack at crash

    00000000ffff09c5()               Unknown
    user32.dll!...                   Unknown
    user32.dll!...                   Unknown
    user32.dll!...                   Unknown
    ntdll.dll!...                    Unknown
    win32u.dll!...                   Unknown
  > fsmapperhook.dll!FollowingManager::captureWindow(HWND, DWORD) Line 460
    fsmapperhook.dll!hookProc(int, WPARAM, LPARAM) Line 731

The faulting address was 0x00000000FFFF09C5, jumped to from inside user32.dll. Notably, hookWndProc does NOT appear in the call stack between captureWindow and the crash. User32.dll is dispatching the window messages triggered by SetWindowPos directly to 0xFFFF09C5, not to hookWndProc.

Inspection of locals in the captureWindow frame showed:

    ctx.original_proc = 0x00000000FFFF09C5

This value was stored at line 423:

    ctx.original_proc = (WNDPROC)::GetWindowLongPtrW(hWnd, GWLP_WNDPROC);

### Root cause

0x00000000FFFF09C5 is a Windows ANSI-to-Unicode wndproc thunk. User32.dll creates these thunks when a Unicode window procedure is installed on a window whose class was registered as ANSI (RegisterClassA). MSFS popup windows use ANSI window classes. The thunk sits between the new Unicode proc and the original ANSI proc, converting string arguments on the way in and out so that ANSI procs receive ANSI data correctly.

GetWindowLongPtrW returns this thunk address as the window's previous procedure. The thunk is not directly callable as a plain function pointer — it is an internal data-driven stub managed by user32.dll. Calling it directly as a function pointer crashes.

callOriginalWindowProc() was doing exactly that:

    return ctx.original_proc(hwnd, msg, wparam, lparam);  // WRONG

Per MSDN (SetWindowLongPtr docs, Remarks):

    "An application must pass any messages not processed by the new window
    procedure to the previous window procedure by calling CallWindowProc."

CallWindowProc correctly handles thunk addresses, routing through the ANSI/Unicode conversion layer as needed.

### Why the crash only occurs on recapture, not first capture

captureWindow sets the window's wndproc by calling NtUserSetWindowLongPtr directly (via the saved IAT entry), bypassing user32.dll's SetWindowLongPtrW wrapper. User32.dll maintains its own internal thunk table, which does not get updated by direct NtUser calls. This creates an inconsistency between what the kernel has stored and what user32.dll's thunk table tracks.

On the first capture, GetWindowLongPtrW returns the raw MSFS function pointer (a normal high-address value) because user32.dll's thunk table has not yet been disturbed. Calling that raw pointer directly works fine.

After the first capture/release cycle, the direct NtUserSetWindowLongPtr calls during capture and release leave user32.dll's thunk table in an inconsistent state. On the second capture, GetWindowLongPtrW now returns 0xFFFF09C5 — the ANSI-to-Unicode thunk — because user32.dll's bookkeeping no longer agrees with the kernel-side state. Direct call to the thunk crashes; CallWindowProcW dispatches through it correctly.

### Fix

    return ::CallWindowProcW(ctx.original_proc, hwnd, msg, wparam, lparam);